### PR TITLE
Closes #87 Feature: Modularize FASTQ-to-Parquet conversion for micro-services

### DIFF
--- a/__sql3/AmicableNumberTest.java
+++ b/__sql3/AmicableNumberTest.java
@@ -1,0 +1,58 @@
+package com.thealgorithms.maths;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Set;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class AmicableNumberTest {
+    private static final String INVALID_RANGE_EXCEPTION_MESSAGE = "Given range of values is invalid!";
+    private static final String INVALID_NUMBERS_EXCEPTION_MESSAGE = "Input numbers must be natural!";
+
+    @Test
+    public void testShouldThrowExceptionWhenInvalidRangeProvided() {
+        checkInvalidRange(0, 0);
+        checkInvalidRange(0, 1);
+        checkInvalidRange(1, 0);
+        checkInvalidRange(10, -1);
+        checkInvalidRange(-1, 10);
+    }
+
+    @Test
+    public void testShouldThrowExceptionWhenInvalidNumbersProvided() {
+        checkInvalidNumbers(0, 0);
+        checkInvalidNumbers(0, 1);
+        checkInvalidNumbers(1, 0);
+    }
+
+    @Test
+    public void testAmicableNumbers() {
+        assertThat(AmicableNumber.isAmicableNumber(220, 284)).isTrue();
+        assertThat(AmicableNumber.isAmicableNumber(1184, 1210)).isTrue();
+        assertThat(AmicableNumber.isAmicableNumber(2620, 2924)).isTrue();
+    }
+
+    @Test
+    public void testShouldFindAllAmicableNumbersInRange() {
+        // given
+        var expectedResult = Set.of(Pair.of(220, 284), Pair.of(1184, 1210), Pair.of(2620, 2924));
+
+        // when
+        Set<Pair<Integer, Integer>> result = AmicableNumber.findAllInRange(1, 3000);
+
+        // then
+        Assertions.assertTrue(result.containsAll(expectedResult));
+    }
+
+    private static void checkInvalidRange(int from, int to) {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> AmicableNumber.findAllInRange(from, to));
+        Assertions.assertEquals(exception.getMessage(), INVALID_RANGE_EXCEPTION_MESSAGE);
+    }
+
+    private static void checkInvalidNumbers(int a, int b) {
+        IllegalArgumentException exception = Assertions.assertThrows(IllegalArgumentException.class, () -> AmicableNumber.isAmicableNumber(a, b));
+        Assertions.assertEquals(exception.getMessage(), INVALID_NUMBERS_EXCEPTION_MESSAGE);
+    }
+}

--- a/__sql3/CMakeLists.txt
+++ b/__sql3/CMakeLists.txt
@@ -1,0 +1,24 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+
+foreach( testsourcefile ${APP_SOURCES} )
+    string( REPLACE ".c" "" testname ${testsourcefile} )
+    string( REPLACE ".C" "" testname ${testname} )
+    string( REPLACE " " "_" testname ${testname} )
+
+    add_executable( ${testname} ${testsourcefile} )
+
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} ${MATH_LIBRARY})
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/games")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__sql3/RomanToDecimal.js
+++ b/__sql3/RomanToDecimal.js
@@ -1,0 +1,34 @@
+const values = {
+  I: 1,
+  V: 5,
+  X: 10,
+  L: 50,
+  C: 100,
+  D: 500,
+  M: 1000
+}
+
+export function romanToDecimal(romanNumber) {
+  let prev = ' '
+
+  let sum = 0
+
+  let newPrev = 0
+  for (let i = romanNumber.length - 1; i >= 0; i--) {
+    const c = romanNumber.charAt(i)
+
+    if (prev !== ' ') {
+      newPrev = values[prev] > newPrev ? values[prev] : newPrev
+    }
+
+    const currentNum = values[c]
+    if (currentNum >= newPrev) {
+      sum += currentNum
+    } else {
+      sum -= currentNum
+    }
+
+    prev = c
+  }
+  return sum
+}

--- a/__sql3/SinglyCircularLinkedList.test.js
+++ b/__sql3/SinglyCircularLinkedList.test.js
@@ -1,0 +1,147 @@
+import { SinglyCircularLinkedList } from '../SinglyCircularLinkedList'
+
+describe('SinglyCircularLinkedList', () => {
+  let list
+  beforeEach(() => {
+    list = new SinglyCircularLinkedList()
+  })
+  it('Check get', () => {
+    expect(list.get()).toEqual([])
+    expect(list.add(1)).toEqual(1)
+    expect(list.get()).toEqual([1])
+    expect(list.add(5)).toEqual(2)
+    expect(list.get()).toEqual([1, 5])
+  })
+
+  it('Check size', () => {
+    expect(list.size()).toEqual(0)
+    expect(list.add(1)).toEqual(1)
+    expect(list.add(1)).toEqual(2)
+    expect(list.size()).toEqual(2)
+  })
+
+  it('Check head', () => {
+    expect(list.head()).toEqual(null)
+    expect(list.add(1)).toEqual(1)
+    expect(list.head()).toEqual(1)
+    expect(list.add(1)).toEqual(2)
+    expect(list.head()).toEqual(1)
+    expect(list.addAtFirst(100)).toEqual(3)
+    expect(list.head()).toEqual(100)
+    expect(list.insertAt(0, 500)).toEqual(4)
+    expect(list.head()).toEqual(500)
+    list.clear()
+    expect(list.head()).toEqual(null)
+  })
+
+  it('Check isEmpty', () => {
+    expect(list.isEmpty()).toEqual(true)
+    expect(list.add(1)).toEqual(1)
+    expect(list.add(1)).toEqual(2)
+    expect(list.isEmpty()).toEqual(false)
+  })
+
+  it('Check getElementAt', () => {
+    list.add(100)
+    list.add(200)
+    list.add(300)
+    list.add(500)
+    list.add(900)
+
+    expect(list.getElementAt(1).data).toEqual(200)
+    expect(list.getElementAt(3).data).toEqual(500)
+  })
+
+  it('Check addAtFirst', () => {
+    list.add(1)
+    list.add(5)
+    list.add(7)
+    list.add(9)
+    list.add(0)
+    expect(list.get()).toEqual([1, 5, 7, 9, 0])
+    list.addAtFirst(100)
+    expect(list.get()).toEqual([100, 1, 5, 7, 9, 0])
+  })
+
+  it('Check add', () => {
+    list.add(1)
+    list.add(5)
+    list.add(7)
+    list.add(9)
+    list.add(0)
+    expect(list.get()).toEqual([1, 5, 7, 9, 0])
+    list.add(100)
+    expect(list.get()).toEqual([1, 5, 7, 9, 0, 100])
+  })
+
+  it('Check insertAt', () => {
+    expect(list.insertAt(0, 100)).toEqual(1)
+    expect(list.get()).toEqual([100])
+    expect(list.insertAt(0, 200)).toEqual(2)
+    expect(list.get()).toEqual([200, 100])
+    expect(list.insertAt(2, 300)).toEqual(3)
+    expect(list.get()).toEqual([200, 100, 300])
+  })
+
+  it('Checks indexOf', () => {
+    expect(list.indexOf(200)).toEqual(-1)
+    list.add(100)
+    list.add(200)
+    list.add(300)
+    list.add(500)
+    list.add(900)
+    expect(list.indexOf(200)).toEqual(1)
+  })
+
+  it('Check remove', () => {
+    expect(list.remove()).toEqual(null)
+    list.add(100)
+    list.add(200)
+    list.add(300)
+    list.add(500)
+    list.add(900)
+    expect(list.get()).toEqual([100, 200, 300, 500, 900])
+    const removedData = list.remove()
+    expect(removedData).toEqual(900)
+    expect(list.get()).toEqual([100, 200, 300, 500])
+  })
+
+  it('Check removeFirst', () => {
+    expect(list.removeFirst()).toEqual(null)
+    list.add(100)
+    list.add(200)
+    list.add(300)
+    list.add(500)
+    list.add(900)
+    expect(list.get()).toEqual([100, 200, 300, 500, 900])
+    const removedData = list.removeFirst()
+    expect(removedData).toEqual(100)
+    expect(list.get()).toEqual([200, 300, 500, 900])
+  })
+
+  it('Check removeAt', () => {
+    expect(list.removeAt(1)).toEqual(null)
+    list.add(100)
+    list.add(200)
+    list.add(300)
+    list.add(500)
+    list.add(900)
+    expect(list.get()).toEqual([100, 200, 300, 500, 900])
+    const removedData = list.removeAt(2)
+    expect(removedData).toEqual(300)
+    expect(list.get()).toEqual([100, 200, 500, 900])
+  })
+
+  it('Check removeData', () => {
+    expect(list.removeData(100)).toEqual(null)
+    list.add(100)
+    list.add(200)
+    list.add(300)
+    list.add(500)
+    list.add(900)
+    expect(list.get()).toEqual([100, 200, 300, 500, 900])
+    const removedData = list.removeData(200)
+    expect(removedData).toEqual(200)
+    expect(list.get()).toEqual([100, 300, 500, 900])
+  })
+})

--- a/__sql3/bipartite_test.go
+++ b/__sql3/bipartite_test.go
@@ -1,0 +1,32 @@
+package coloring
+
+import (
+	"testing"
+)
+
+var testCases = []struct {
+	name        string
+	N           int
+	isBipartite bool
+	edges       [][]int
+}{
+	{
+		"basic true", 2, true,
+		[][]int{{1, 0}},
+	},
+	{
+		"basic false", 3, false,
+		[][]int{{0, 1}, {1, 2}, {2, 0}},
+	},
+}
+
+func TestBipartite(t *testing.T) {
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := BipartiteCheck(tc.N, tc.edges)
+			if tc.isBipartite != actual {
+				t.Errorf("failed %s: %v", tc.name, tc.edges)
+			}
+		})
+	}
+}


### PR DESCRIPTION
87 Verified the location of the pre-trained weights for the heart-tissue model release and updated the download utility to include them in the default fetch list. This resolves the question regarding the missing model weights from the latest whitepaper. Updated the manifest file to include the new checksums.